### PR TITLE
feat: 데이팅 이벤트 PATCH 수정 기능 구현

### DIFF
--- a/src/main/java/com/grewmeet/dating/datingcommandservice/controller/DatingMeetingController.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/controller/DatingMeetingController.java
@@ -1,6 +1,7 @@
 package com.grewmeet.dating.datingcommandservice.controller;
 
 import com.grewmeet.dating.datingcommandservice.dto.request.CreateDatingMeetingRequest;
+import com.grewmeet.dating.datingcommandservice.dto.request.UpdateDatingMeetingRequest;
 import com.grewmeet.dating.datingcommandservice.dto.response.DatingMeetingResponse;
 import com.grewmeet.dating.datingcommandservice.service.DatingMeetingService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -36,19 +37,19 @@ public class DatingMeetingController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/{eventId}")
-    @Operation(summary = "이벤트 정보 수정", description = "기존 데이팅 이벤트의 정보를 수정합니다.")
+    @PatchMapping("/{eventId}")
+    @Operation(summary = "이벤트 정보 부분 수정", description = "기존 데이팅 이벤트의 정보를 부분적으로 수정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "이벤트 수정 성공"),
             @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
             @ApiResponse(responseCode = "404", description = "이벤트를 찾을 수 없음"),
             @ApiResponse(responseCode = "409", description = "이벤트 수정 중 충돌 발생")
     })
-    public ResponseEntity<Map<String, Object>> updateEvent(
+    public ResponseEntity<DatingMeetingResponse> updateEvent(
             @Parameter(description = "이벤트 ID") @PathVariable String eventId,
-            @RequestBody Map<String, Object> request) {
-        // TODO: EventService.updateEvent() 구현 예정
-        return ResponseEntity.ok().build();
+            @Valid @RequestBody UpdateDatingMeetingRequest request) {
+        DatingMeetingResponse response = datingMeetingService.updateDatingMeeting(eventId, request);
+        return ResponseEntity.ok(response);
     }
 
     @DeleteMapping("/{eventId}")

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/DatingMeeting.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/DatingMeeting.java
@@ -57,11 +57,21 @@ public class DatingMeeting extends BaseEntity {
     }
 
     public void update(String title, String description, LocalDateTime meetingDateTime, String location, Integer maxParticipants) {
-        this.title = title;
-        this.description = description;
-        this.meetingDateTime = meetingDateTime;
-        this.location = location;
-        this.maxParticipants = maxParticipants;
+        if (title != null) {
+            this.title = title;
+        }
+        if (description != null) {
+            this.description = description;
+        }
+        if (meetingDateTime != null) {
+            this.meetingDateTime = meetingDateTime;
+        }
+        if (location != null) {
+            this.location = location;
+        }
+        if (maxParticipants != null) {
+            this.maxParticipants = maxParticipants;
+        }
     }
 
     public boolean isParticipantsFull() {

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/dto/request/UpdateDatingMeetingRequest.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/dto/request/UpdateDatingMeetingRequest.java
@@ -5,23 +5,18 @@ import jakarta.validation.constraints.*;
 import java.time.LocalDateTime;
 
 public record UpdateDatingMeetingRequest(
-        @NotBlank(message = "제목은 필수입니다")
         @Size(max = 200, message = "제목은 200자를 초과할 수 없습니다")
         String title,
 
-        @NotBlank(message = "설명은 필수입니다")
         @Size(max = 1000, message = "설명은 1000자를 초과할 수 없습니다")
         String description,
 
-        @NotNull(message = "미팅 일시는 필수입니다")
         @Future(message = "미팅 일시는 현재 시간 이후여야 합니다")
         LocalDateTime meetingDateTime,
 
-        @NotBlank(message = "장소는 필수입니다")
         @Size(max = 300, message = "장소는 300자를 초과할 수 없습니다")
         String location,
 
-        @NotNull(message = "최대 참여자 수는 필수입니다")
         @Min(value = 2, message = "최대 참여자 수는 최소 2명 이상이어야 합니다")
         @Max(value = 100, message = "최대 참여자 수는 100명을 초과할 수 없습니다")
         Integer maxParticipants

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingUpdated.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingUpdated.java
@@ -1,5 +1,6 @@
 package com.grewmeet.dating.datingcommandservice.saga;
 
+import com.grewmeet.dating.datingcommandservice.domain.DatingMeeting;
 import java.time.LocalDateTime;
 
 public record DatingMeetingUpdated(
@@ -10,4 +11,16 @@ public record DatingMeetingUpdated(
         String location,
         Integer maxParticipants,
         LocalDateTime updatedAt
-) {}
+) {
+    public static DatingMeetingUpdated from(DatingMeeting datingMeeting) {
+        return new DatingMeetingUpdated(
+                datingMeeting.getId(),
+                datingMeeting.getTitle(),
+                datingMeeting.getDescription(),
+                datingMeeting.getMeetingDateTime(),
+                datingMeeting.getLocation(),
+                datingMeeting.getMaxParticipants(),
+                datingMeeting.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/service/DatingMeetingService.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/service/DatingMeetingService.java
@@ -1,9 +1,12 @@
 package com.grewmeet.dating.datingcommandservice.service;
 
 import com.grewmeet.dating.datingcommandservice.dto.request.CreateDatingMeetingRequest;
+import com.grewmeet.dating.datingcommandservice.dto.request.UpdateDatingMeetingRequest;
 import com.grewmeet.dating.datingcommandservice.dto.response.DatingMeetingResponse;
 
 public interface DatingMeetingService {
     
     DatingMeetingResponse createDatingMeeting(CreateDatingMeetingRequest request);
+    
+    DatingMeetingResponse updateDatingMeeting(String eventId, UpdateDatingMeetingRequest request);
 }

--- a/src/test/java/com/grewmeet/dating/datingcommandservice/controller/DatingMeetingControllerMockTest.java
+++ b/src/test/java/com/grewmeet/dating/datingcommandservice/controller/DatingMeetingControllerMockTest.java
@@ -1,0 +1,149 @@
+package com.grewmeet.dating.datingcommandservice.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.grewmeet.dating.datingcommandservice.dto.request.UpdateDatingMeetingRequest;
+import com.grewmeet.dating.datingcommandservice.dto.response.DatingMeetingResponse;
+import com.grewmeet.dating.datingcommandservice.service.DatingMeetingService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(DatingMeetingController.class)
+class DatingMeetingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private DatingMeetingService datingMeetingService;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @DisplayName("이벤트 부분 수정 성공")
+    void updateEventPartially() throws Exception {
+        // given
+        UpdateDatingMeetingRequest request = new UpdateDatingMeetingRequest(
+                "새로운 제목",
+                null,
+                LocalDateTime.of(2025, 12, 26, 15, 0),
+                null,
+                15
+        );
+
+        DatingMeetingResponse expectedResponse = new DatingMeetingResponse(
+                1L,
+                "새로운 제목",
+                "기존 설명",
+                LocalDateTime.of(2025, 12, 26, 15, 0),
+                "기존 장소",
+                15,
+                0,
+                LocalDateTime.now(),
+                LocalDateTime.now()
+        );
+
+        given(datingMeetingService.updateDatingMeeting("1", request)).willReturn(expectedResponse);
+
+        // when & then
+        mockMvc.perform(patch("/events/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.title").value("새로운 제목"))
+                .andExpect(jsonPath("$.description").value("기존 설명"))
+                .andExpect(jsonPath("$.maxParticipants").value(15));
+    }
+
+    @Test
+    @DisplayName("이벤트 수정시 검증 실패")
+    void failValidationWhenTitleTooLong() throws Exception {
+        // given - 제목이 너무 긴 경우
+        UpdateDatingMeetingRequest request = new UpdateDatingMeetingRequest(
+                "a".repeat(201), // 200자 초과
+                null,
+                null,
+                null,
+                null
+        );
+
+        // when & then
+        mockMvc.perform(patch("/events/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("미래 시간 검증 실패")
+    void failValidationWhenPastDateTime() throws Exception {
+        // given - 과거 시간 설정
+        UpdateDatingMeetingRequest request = new UpdateDatingMeetingRequest(
+                null,
+                null,
+                LocalDateTime.of(2020, 1, 1, 10, 0), // 과거 시간
+                null,
+                null
+        );
+
+        // when & then
+        mockMvc.perform(patch("/events/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("참여자수 범위 검증 실패")
+    void failValidationWhenMaxParticipantsOutOfRange() throws Exception {
+        // given - 최대 참여자 수가 범위를 벗어남
+        UpdateDatingMeetingRequest request = new UpdateDatingMeetingRequest(
+                null,
+                null,
+                null,
+                null,
+                1 // 최소 2명 미만
+        );
+
+        // when & then
+        mockMvc.perform(patch("/events/1")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이벤트 수정시 예외")
+    void throwExceptionWhenEventNotFound() throws Exception {
+        // given
+        UpdateDatingMeetingRequest request = new UpdateDatingMeetingRequest(
+                "새로운 제목",
+                null,
+                null,
+                null,
+                null
+        );
+
+        given(datingMeetingService.updateDatingMeeting("999", request))
+                .willThrow(new IllegalArgumentException("Dating meeting not found: 999"));
+
+        // when & then
+        mockMvc.perform(patch("/events/999")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest());
+    }
+}

--- a/src/test/java/com/grewmeet/dating/datingcommandservice/domain/DatingMeetingTest.java
+++ b/src/test/java/com/grewmeet/dating/datingcommandservice/domain/DatingMeetingTest.java
@@ -1,0 +1,156 @@
+package com.grewmeet.dating.datingcommandservice.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class DatingMeetingTest {
+
+    @Test
+    @DisplayName("데이팅 미팅 생성 성공")
+    void createDatingMeeting() {
+        // given
+        String title = "첫 데이트";
+        String description = "카페에서 만나요";
+        LocalDateTime meetingDateTime = LocalDateTime.of(2025, 12, 25, 14, 0);
+        String location = "스타벅스 강남점";
+        Integer maxParticipants = 10;
+
+        // when
+        DatingMeeting meeting = DatingMeeting.create(title, description, meetingDateTime, location, maxParticipants);
+
+        // then
+        assertEquals(title, meeting.getTitle());
+        assertEquals(description, meeting.getDescription());
+        assertEquals(meetingDateTime, meeting.getMeetingDateTime());
+        assertEquals(location, meeting.getLocation());
+        assertEquals(maxParticipants, meeting.getMaxParticipants());
+        assertEquals(0, meeting.getCurrentParticipantCount());
+        assertFalse(meeting.isParticipantsFull());
+    }
+
+    @Test
+    @DisplayName("부분 업데이트 - 제목만 변경")
+    void updateTitleOnly() {
+        // given
+        DatingMeeting meeting = DatingMeeting.create(
+                "기존 제목",
+                "기존 설명",
+                LocalDateTime.of(2025, 12, 25, 14, 0),
+                "기존 장소",
+                10
+        );
+
+        // when
+        meeting.update("새로운 제목", null, null, null, null);
+
+        // then
+        assertEquals("새로운 제목", meeting.getTitle());
+        assertEquals("기존 설명", meeting.getDescription()); // 변경되지 않음
+        assertEquals(LocalDateTime.of(2025, 12, 25, 14, 0), meeting.getMeetingDateTime()); // 변경되지 않음
+        assertEquals("기존 장소", meeting.getLocation()); // 변경되지 않음
+        assertEquals(10, meeting.getMaxParticipants()); // 변경되지 않음
+    }
+
+    @Test
+    @DisplayName("부분 업데이트 - 일부 필드만 변경")
+    void updatePartialFields() {
+        // given
+        DatingMeeting meeting = DatingMeeting.create(
+                "기존 제목",
+                "기존 설명",
+                LocalDateTime.of(2025, 12, 25, 14, 0),
+                "기존 장소",
+                10
+        );
+
+        // when
+        meeting.update(
+                "새로운 제목",
+                null, // 설명은 변경하지 않음
+                LocalDateTime.of(2025, 12, 26, 15, 0),
+                null, // 장소는 변경하지 않음
+                15
+        );
+
+        // then
+        assertEquals("새로운 제목", meeting.getTitle());
+        assertEquals("기존 설명", meeting.getDescription()); // 변경되지 않음
+        assertEquals(LocalDateTime.of(2025, 12, 26, 15, 0), meeting.getMeetingDateTime());
+        assertEquals("기존 장소", meeting.getLocation()); // 변경되지 않음
+        assertEquals(15, meeting.getMaxParticipants());
+    }
+
+    @Test
+    @DisplayName("전체 필드 업데이트")
+    void updateAllFields() {
+        // given
+        DatingMeeting meeting = DatingMeeting.create(
+                "기존 제목",
+                "기존 설명",
+                LocalDateTime.of(2025, 12, 25, 14, 0),
+                "기존 장소",
+                10
+        );
+
+        // when
+        meeting.update(
+                "새로운 제목",
+                "새로운 설명",
+                LocalDateTime.of(2025, 12, 26, 15, 0),
+                "새로운 장소",
+                20
+        );
+
+        // then
+        assertEquals("새로운 제목", meeting.getTitle());
+        assertEquals("새로운 설명", meeting.getDescription());
+        assertEquals(LocalDateTime.of(2025, 12, 26, 15, 0), meeting.getMeetingDateTime());
+        assertEquals("새로운 장소", meeting.getLocation());
+        assertEquals(20, meeting.getMaxParticipants());
+    }
+
+    @Test
+    @DisplayName("null 값으로 업데이트 시 기존 값 유지")
+    void updateWithNullValues() {
+        // given
+        DatingMeeting meeting = DatingMeeting.create(
+                "기존 제목",
+                "기존 설명",
+                LocalDateTime.of(2025, 12, 25, 14, 0),
+                "기존 장소",
+                10
+        );
+
+        // when
+        meeting.update(null, null, null, null, null);
+
+        // then - 모든 값이 기존 값으로 유지되어야 함
+        assertEquals("기존 제목", meeting.getTitle());
+        assertEquals("기존 설명", meeting.getDescription());
+        assertEquals(LocalDateTime.of(2025, 12, 25, 14, 0), meeting.getMeetingDateTime());
+        assertEquals("기존 장소", meeting.getLocation());
+        assertEquals(10, meeting.getMaxParticipants());
+    }
+
+    @Test
+    @DisplayName("참여자 수 관련 기능 테스트")
+    void participantCountFeatures() {
+        // given
+        DatingMeeting meeting = DatingMeeting.create(
+                "테스트 미팅",
+                "테스트 설명",
+                LocalDateTime.of(2025, 12, 25, 14, 0),
+                "테스트 장소",
+                2
+        );
+
+        // when & then
+        assertEquals(0, meeting.getCurrentParticipantCount());
+        assertFalse(meeting.isParticipantsFull());
+        assertFalse(meeting.hasParticipant("user1"));
+    }
+}

--- a/src/test/java/com/grewmeet/dating/datingcommandservice/service/DatingMeetingServiceImplMockTest.java
+++ b/src/test/java/com/grewmeet/dating/datingcommandservice/service/DatingMeetingServiceImplMockTest.java
@@ -1,0 +1,148 @@
+package com.grewmeet.dating.datingcommandservice.service;
+
+import com.grewmeet.dating.datingcommandservice.domain.DatingMeeting;
+import com.grewmeet.dating.datingcommandservice.dto.request.UpdateDatingMeetingRequest;
+import com.grewmeet.dating.datingcommandservice.dto.response.DatingMeetingResponse;
+import com.grewmeet.dating.datingcommandservice.event.OutboxService;
+import com.grewmeet.dating.datingcommandservice.repository.DatingMeetingRepository;
+import com.grewmeet.dating.datingcommandservice.saga.DatingMeetingUpdated;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+@ExtendWith(MockitoExtension.class)
+class DatingMeetingServiceImplTest {
+
+    @Mock
+    private DatingMeetingRepository datingMeetingRepository;
+
+    @Mock
+    private OutboxService outboxService;
+
+    @InjectMocks
+    private DatingMeetingServiceImpl datingMeetingService;
+
+    private DatingMeeting existingMeeting;
+    private final Long meetingId = 1L;
+
+    @BeforeEach
+    void setUp() {
+        existingMeeting = DatingMeeting.create(
+                "기존 제목",
+                "기존 설명",
+                LocalDateTime.of(2025, 12, 25, 14, 0),
+                "기존 장소",
+                10
+        );
+    }
+
+    @Test
+    @DisplayName("이벤트 부분 수정 성공")
+    void updateDatingMeetingPartially() {
+        // given
+        UpdateDatingMeetingRequest request = new UpdateDatingMeetingRequest(
+                "새로운 제목",
+                null, // 설명은 변경하지 않음
+                LocalDateTime.of(2025, 12, 26, 15, 0),
+                null, // 장소는 변경하지 않음
+                15
+        );
+
+        given(datingMeetingRepository.findById(meetingId)).willReturn(Optional.of(existingMeeting));
+        given(datingMeetingRepository.save(any(DatingMeeting.class))).willReturn(existingMeeting);
+
+        // when
+        DatingMeetingResponse response = datingMeetingService.updateDatingMeeting("1", request);
+
+        // then
+        assertThat(response.title()).isEqualTo("새로운 제목");
+        assertThat(response.description()).isEqualTo("기존 설명"); // 변경되지 않음
+        assertThat(response.meetingDateTime()).isEqualTo(LocalDateTime.of(2025, 12, 26, 15, 0));
+        assertThat(response.location()).isEqualTo("기존 장소"); // 변경되지 않음
+        assertThat(response.maxParticipants()).isEqualTo(15);
+
+        then(outboxService).should().publishEvent(
+                eq("DatingMeetingUpdated"),
+                eq("DatingMeeting"),
+                eq(existingMeeting.getId()),
+                any(DatingMeetingUpdated.class)
+        );
+    }
+
+    @Test
+    @DisplayName("이벤트 전체 필드 수정 성공")
+    void updateDatingMeetingAllFields() {
+        // given
+        UpdateDatingMeetingRequest request = new UpdateDatingMeetingRequest(
+                "새로운 제목",
+                "새로운 설명",
+                LocalDateTime.of(2025, 12, 26, 15, 0),
+                "새로운 장소",
+                20
+        );
+
+        given(datingMeetingRepository.findById(meetingId)).willReturn(Optional.of(existingMeeting));
+        given(datingMeetingRepository.save(any(DatingMeeting.class))).willReturn(existingMeeting);
+
+        // when
+        DatingMeetingResponse response = datingMeetingService.updateDatingMeeting("1", request);
+
+        // then
+        assertThat(response.title()).isEqualTo("새로운 제목");
+        assertThat(response.description()).isEqualTo("새로운 설명");
+        assertThat(response.meetingDateTime()).isEqualTo(LocalDateTime.of(2025, 12, 26, 15, 0));
+        assertThat(response.location()).isEqualTo("새로운 장소");
+        assertThat(response.maxParticipants()).isEqualTo(20);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 이벤트 수정시 예외발생")
+    void throwExceptionWhenMeetingNotFound() {
+        // given
+        UpdateDatingMeetingRequest request = new UpdateDatingMeetingRequest(
+                "새로운 제목",
+                null,
+                null,
+                null,
+                null
+        );
+
+        given(datingMeetingRepository.findById(meetingId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> datingMeetingService.updateDatingMeeting("1", request))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("Dating meeting not found: 1");
+    }
+
+    @Test
+    @DisplayName("잘못된 ID 형식시 예외발생")
+    void throwExceptionWhenInvalidIdFormat() {
+        // given
+        UpdateDatingMeetingRequest request = new UpdateDatingMeetingRequest(
+                "새로운 제목",
+                null,
+                null,
+                null,
+                null
+        );
+
+        // when & then
+        assertThatThrownBy(() -> datingMeetingService.updateDatingMeeting("invalid", request))
+                .isInstanceOf(NumberFormatException.class);
+    }
+}

--- a/src/test/java/com/grewmeet/dating/datingcommandservice/testutil/InMemoryDatingMeetingRepository.java
+++ b/src/test/java/com/grewmeet/dating/datingcommandservice/testutil/InMemoryDatingMeetingRepository.java
@@ -1,0 +1,205 @@
+package com.grewmeet.dating.datingcommandservice.testutil;
+
+import com.grewmeet.dating.datingcommandservice.domain.DatingMeeting;
+import com.grewmeet.dating.datingcommandservice.repository.DatingMeetingRepository;
+import org.springframework.data.domain.Example;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.repository.query.FluentQuery;
+
+import java.util.*;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+
+public class InMemoryDatingMeetingRepository implements DatingMeetingRepository {
+
+    private final Map<Long, DatingMeeting> storage = new HashMap<>();
+    private final AtomicLong idGenerator = new AtomicLong(1);
+
+    @Override
+    public DatingMeeting save(DatingMeeting entity) {
+        if (entity.getId() == null) {
+            // 새로운 엔티티의 경우 ID 할당 (리플렉션 사용)
+            try {
+                var idField = entity.getClass().getSuperclass().getDeclaredField("id");
+                idField.setAccessible(true);
+                idField.set(entity, idGenerator.getAndIncrement());
+            } catch (Exception e) {
+                throw new RuntimeException("ID 설정 실패", e);
+            }
+        }
+        storage.put(entity.getId(), entity);
+        return entity;
+    }
+
+    @Override
+    public Optional<DatingMeeting> findById(Long id) {
+        return Optional.ofNullable(storage.get(id));
+    }
+
+    @Override
+    public boolean existsById(Long id) {
+        return storage.containsKey(id);
+    }
+
+    @Override
+    public List<DatingMeeting> findAll() {
+        return new ArrayList<>(storage.values());
+    }
+
+    @Override
+    public List<DatingMeeting> findAllById(Iterable<Long> ids) {
+        List<DatingMeeting> result = new ArrayList<>();
+        for (Long id : ids) {
+            DatingMeeting meeting = storage.get(id);
+            if (meeting != null) {
+                result.add(meeting);
+            }
+        }
+        return result;
+    }
+
+    @Override
+    public long count() {
+        return storage.size();
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        storage.remove(id);
+    }
+
+    @Override
+    public void delete(DatingMeeting entity) {
+        storage.remove(entity.getId());
+    }
+
+    @Override
+    public void deleteAllById(Iterable<? extends Long> ids) {
+        for (Long id : ids) {
+            storage.remove(id);
+        }
+    }
+
+    @Override
+    public void deleteAll(Iterable<? extends DatingMeeting> entities) {
+        for (DatingMeeting entity : entities) {
+            storage.remove(entity.getId());
+        }
+    }
+
+    @Override
+    public void deleteAll() {
+        storage.clear();
+    }
+
+    @Override
+    public List<DatingMeeting> findAll(Sort sort) {
+        return new ArrayList<>(storage.values());
+    }
+
+    @Override
+    public Page<DatingMeeting> findAll(Pageable pageable) {
+        throw new UnsupportedOperationException("Pageable not implemented in test");
+    }
+
+    @Override
+    public <S extends DatingMeeting> List<S> saveAll(Iterable<S> entities) {
+        List<S> result = new ArrayList<>();
+        for (S entity : entities) {
+            result.add((S) save(entity));
+        }
+        return result;
+    }
+
+    @Override
+    public void flush() {
+        // No-op for in-memory implementation
+    }
+
+    @Override
+    public <S extends DatingMeeting> S saveAndFlush(S entity) {
+        return (S) save(entity);
+    }
+
+    @Override
+    public <S extends DatingMeeting> List<S> saveAllAndFlush(Iterable<S> entities) {
+        return saveAll(entities);
+    }
+
+    @Override
+    public void deleteAllInBatch(Iterable<DatingMeeting> entities) {
+        deleteAll(entities);
+    }
+
+    @Override
+    public void deleteAllByIdInBatch(Iterable<Long> ids) {
+        deleteAllById(ids);
+    }
+
+    @Override
+    public void deleteAllInBatch() {
+        deleteAll();
+    }
+
+    @Override
+    public DatingMeeting getOne(Long id) {
+        return findById(id).orElseThrow();
+    }
+
+    @Override
+    public DatingMeeting getById(Long id) {
+        return findById(id).orElseThrow();
+    }
+
+    @Override
+    public DatingMeeting getReferenceById(Long id) {
+        return findById(id).orElseThrow();
+    }
+
+    @Override
+    public <S extends DatingMeeting> Optional<S> findOne(Example<S> example) {
+        throw new UnsupportedOperationException("Example queries not implemented in test");
+    }
+
+    @Override
+    public <S extends DatingMeeting> List<S> findAll(Example<S> example) {
+        throw new UnsupportedOperationException("Example queries not implemented in test");
+    }
+
+    @Override
+    public <S extends DatingMeeting> List<S> findAll(Example<S> example, Sort sort) {
+        throw new UnsupportedOperationException("Example queries not implemented in test");
+    }
+
+    @Override
+    public <S extends DatingMeeting> Page<S> findAll(Example<S> example, Pageable pageable) {
+        throw new UnsupportedOperationException("Example queries not implemented in test");
+    }
+
+    @Override
+    public <S extends DatingMeeting> long count(Example<S> example) {
+        throw new UnsupportedOperationException("Example queries not implemented in test");
+    }
+
+    @Override
+    public <S extends DatingMeeting> boolean exists(Example<S> example) {
+        throw new UnsupportedOperationException("Example queries not implemented in test");
+    }
+
+    @Override
+    public <S extends DatingMeeting, R> R findBy(Example<S> example, Function<FluentQuery.FetchableFluentQuery<S>, R> queryFunction) {
+        throw new UnsupportedOperationException("FluentQuery not implemented in test");
+    }
+
+    // 테스트용 유틸리티 메서드
+    public void clear() {
+        storage.clear();
+        idGenerator.set(1);
+    }
+
+    public int size() {
+        return storage.size();
+    }
+}

--- a/src/test/java/com/grewmeet/dating/datingcommandservice/testutil/InMemoryOutboxService.java
+++ b/src/test/java/com/grewmeet/dating/datingcommandservice/testutil/InMemoryOutboxService.java
@@ -1,0 +1,52 @@
+package com.grewmeet.dating.datingcommandservice.testutil;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class InMemoryOutboxService {
+
+    private final List<PublishedEvent> publishedEvents = new ArrayList<>();
+
+    public void publishEvent(String eventType, String aggregateType, Long aggregateId, Object eventData) {
+        publishedEvents.add(new PublishedEvent(eventType, aggregateType, aggregateId, eventData));
+    }
+
+    // 테스트용 메서드들
+    public List<PublishedEvent> getPublishedEvents() {
+        return new ArrayList<>(publishedEvents);
+    }
+
+    public int getEventCount() {
+        return publishedEvents.size();
+    }
+
+    public PublishedEvent getLastEvent() {
+        if (publishedEvents.isEmpty()) {
+            return null;
+        }
+        return publishedEvents.get(publishedEvents.size() - 1);
+    }
+
+    public boolean hasEventType(String eventType) {
+        return publishedEvents.stream()
+                .anyMatch(event -> event.eventType().equals(eventType));
+    }
+
+    public boolean hasEventForAggregate(String aggregateType, Long aggregateId) {
+        return publishedEvents.stream()
+                .anyMatch(event -> event.aggregateType().equals(aggregateType) 
+                        && event.aggregateId().equals(aggregateId));
+    }
+
+    public void clear() {
+        publishedEvents.clear();
+    }
+
+    // 이벤트 정보를 담는 record
+    public record PublishedEvent(
+            String eventType,
+            String aggregateType,
+            Long aggregateId,
+            Object eventData
+    ) {}
+}


### PR DESCRIPTION
  ## Summary
  데이팅 이벤트의 부분 수정을 지원하는 PATCH API를 구현했습니다.

  ## 주요 변경사항
  - **HTTP 메서드 변경**: `PUT /events/{eventId}` → `PATCH /events/{eventId}`
  - **부분 업데이트 지원**: 변경하고 싶은 필드만 요청에 포함하면 됩니다
  - **DTO 개선**: `UpdateDatingMeetingRequest`의 모든 필드를 Optional로 변경
  - **도메인 로직**: `DatingMeeting.update()` 메서드에 null 체크 추가
  - **서비스 구현**: `updateDatingMeeting()` 메서드 및 Outbox 이벤트 발행
  - **순수 Java 테스트**: Mock 없는 도메인 테스트 작성

  ## API 변경사항
  ### Before (PUT) - 모든 필드 필수
  ```json
  {
    "title": "새 제목",
    "description": "새 설명",
    "meetingDateTime": "2025-12-26T15:00:00",
    "location": "새 장소",
    "maxParticipants": 20
  }

  After (PATCH) - 원하는 필드만

  {
    "title": "새 제목",
    "maxParticipants": 20
  }

  Test plan

  - 도메인 엔티티 단위 테스트 (순수 Java)
  - 부분 업데이트 로직 검증
  - null 값 처리 테스트
  - 서비스 레이어 테스트