### PR TITLE
 refactor: UUID 기반 Event-Driven Architecture 전환

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,46 @@
 # Dating Command Service
 
-데이팅 도메인의 명령 서비스 (데이팅 이벤트 생성, 수정, 삭제, 참여/탈퇴)
+데이팅 도메인의 명령 서비스 (데이팅 모임 생성, 수정, 삭제, 참여/탈퇴)
 
 ## 🔧 환경 설정
 - **포트**: 8080 (기본값)
 - **데이터베이스**: H2 (인메모리)
-- **Kafka**: localhost:9092
+- **Framework**: Spring Boot 3.5.3, Java 21
 
-## 📡 이벤트 발행
+## 🏗️ 아키텍처
+- **CQRS Command Side** (쓰기 전용, 복잡한 조회 로직 없음)
+- **Outbox Pattern** (DB 트랜잭션 내 이벤트 기록, Kafka는 별도 Relay에서 발행)
+- **Event-Driven Architecture** (UUID 기반 이벤트 통신)
+- **Domain-Driven Design** 기반 구조
+
+## 📡 이벤트 발행 (UUID 기반 EDA)
 CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤트 발행:
 
 | 이벤트 타입 | Aggregate 타입 | 설명 | 발생 시점 |
 |------------|---------------|------|----------|
-| `DatingMeetingCreated` | DatingMeeting | 데이팅 이벤트 생성 | POST /events |
-| `DatingMeetingUpdated` | DatingMeeting | 데이팅 이벤트 수정 | PATCH /events/{id} |
-| `DatingMeetingDeleted` | DatingMeeting | 데이팅 이벤트 삭제 | DELETE /events/{id} |
-| `DatingMeetingParticipantJoined` | DatingMeetingParticipant | 이벤트 참여 | POST /events/{id}/participants |
-| `DatingMeetingParticipantLeft` | DatingMeetingParticipant | 이벤트 탈퇴 | DELETE /events/{id}/participants/{pid} |
+| `DatingMeetingCreated` | DatingMeeting | 데이팅 모임 생성 | POST /events |
+| `DatingMeetingUpdated` | DatingMeeting | 데이팅 모임 수정 | PATCH /events/{id} |
+| `DatingMeetingDeleted` | DatingMeeting | 데이팅 모임 삭제 | DELETE /events/{id} |
+| `DatingMeetingParticipantJoined` | DatingMeetingParticipant | 모임 참여 | POST /events/{id}/participants |
+| `DatingMeetingParticipantLeft` | DatingMeetingParticipant | 모임 탈퇴 | DELETE /events/{id}/participants/{pid} |
 
 ### DatingMeetingCreated
 ```json
 {
   "eventType": "DatingMeetingCreated",
   "aggregateType": "DatingMeeting",
-  "aggregateId": 123,
-  "data": {
-    "datingMeetingId": 123,
+  "aggregateId": "550e8400-e29b-41d4-a716-446655440000",
+  "payload": {
+    "meetingUuid": "550e8400-e29b-41d4-a716-446655440000",
     "title": "서울 강남 데이팅 모임",
     "description": "강남에서 만나는 데이팅 모임입니다",
-    "meetingDateTime": "2024-08-21T19:00:00",
+    "hostAuthUserId": "123e4567-e89b-12d3-a456-426614174000",
+    "hostNickname": "홍길동",
+    "meetingDateTime": "2025-01-20T19:00:00",
     "location": "강남역 스타벅스",
-    "maxParticipants": 10,
-    "createdAt": "2024-08-21T14:30:00"
+    "maxMaleParticipants": 5,
+    "maxFemaleParticipants": 5,
+    "createdAt": "2025-01-13T14:30:00"
   }
 }
 ```
@@ -41,15 +50,16 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
 {
   "eventType": "DatingMeetingUpdated",
   "aggregateType": "DatingMeeting",
-  "aggregateId": 123,
-  "data": {
-    "datingMeetingId": 123,
+  "aggregateId": "550e8400-e29b-41d4-a716-446655440000",
+  "payload": {
+    "meetingUuid": "550e8400-e29b-41d4-a716-446655440000",
     "title": "서울 강남 데이팅 모임 (수정)",
     "description": "강남에서 만나는 데이팅 모임입니다",
-    "meetingDateTime": "2024-08-22T19:00:00",
+    "meetingDateTime": "2025-01-22T19:00:00",
     "location": "강남역 카페",
-    "maxParticipants": 8,
-    "updatedAt": "2024-08-21T15:30:00"
+    "maxMaleParticipants": 4,
+    "maxFemaleParticipants": 4,
+    "updatedAt": "2025-01-13T15:30:00"
   }
 }
 ```
@@ -59,12 +69,13 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
 {
   "eventType": "DatingMeetingDeleted",
   "aggregateType": "DatingMeeting",
-  "aggregateId": 123,
-  "data": {
-    "datingMeetingId": 123,
+  "aggregateId": "550e8400-e29b-41d4-a716-446655440000",
+  "payload": {
+    "meetingUuid": "550e8400-e29b-41d4-a716-446655440000",
     "title": "서울 강남 데이팅 모임",
-    "participantIds": [1, 2, 3],
-    "deletedAt": "2024-08-21T16:00:00"
+    "maxMaleParticipants": 5,
+    "maxFemaleParticipants": 5,
+    "deletedAt": "2025-01-13T16:00:00"
   }
 }
 ```
@@ -74,12 +85,14 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
 {
   "eventType": "DatingMeetingParticipantJoined",
   "aggregateType": "DatingMeetingParticipant",
-  "aggregateId": 456,
-  "data": {
-    "datingMeetingId": 123,
-    "participantId": 456,
-    "userId": 987654321,
-    "joinedAt": "2024-08-21T17:00:00"
+  "aggregateId": "550e8400-e29b-41d4-a716-446655440000",
+  "payload": {
+    "meetingUuid": "550e8400-e29b-41d4-a716-446655440000",
+    "authUserId": "789e0123-e89b-12d3-a456-426614174001",
+    "gender": "MALE",
+    "meetingTitle": "서울 강남 데이팅 모임",
+    "meetingDateTime": "2025-01-20T19:00:00",
+    "joinedAt": "2025-01-13T17:00:00"
   }
 }
 ```
@@ -89,12 +102,12 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
 {
   "eventType": "DatingMeetingParticipantLeft",
   "aggregateType": "DatingMeetingParticipant",
-  "aggregateId": 456,
-  "data": {
-    "datingMeetingId": 123,
-    "participantId": 456,
-    "userId": 987654321,
-    "leftAt": "2024-08-21T18:00:00"
+  "aggregateId": "550e8400-e29b-41d4-a716-446655440000",
+  "payload": {
+    "meetingUuid": "550e8400-e29b-41d4-a716-446655440000",
+    "authUserId": "789e0123-e89b-12d3-a456-426614174001",
+    "gender": "MALE",
+    "leftAt": "2025-01-13T18:00:00"
   }
 }
 ```
@@ -106,14 +119,34 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
 
 ## 📋 API 엔드포인트
 
-### 이벤트 관리
-- **POST** `/events` - 새 데이팅 이벤트 생성
-- **PATCH** `/events/{datingMeetingId}` - 이벤트 정보 부분 수정
-- **DELETE** `/events/{datingMeetingId}` - 이벤트 삭제
+### 데이팅 모임 관리
+- **POST** `/events` - 새 데이팅 모임 생성 (Host만 가능)
+  - Request Header: `X-User-Id` (UUID 형식 - Host 사용자 식별)
+  - Request Body: `CreateDatingMeetingRequest` (title, description, meetingDateTime, location, maxMaleParticipants, maxFemaleParticipants)
+  - Response: `DatingMeetingResponse` (모임 정보)
+
+- **PATCH** `/events/{datingMeetingId}` - 모임 정보 부분 수정
+  - Path Variable: `datingMeetingId` (Long - 내부 DB ID)
+  - Request Body: `UpdateDatingMeetingRequest` (모든 필드 Optional)
+  - Response: `DatingMeetingResponse` (수정된 모임 정보)
+
+- **DELETE** `/events/{datingMeetingId}` - 모임 삭제
+  - Path Variable: `datingMeetingId` (Long - 내부 DB ID)
+  - Response: 204 No Content
 
 ### 참여자 관리
-- **POST** `/events/{datingMeetingId}/participants` - 이벤트 참여
-- **DELETE** `/events/{datingMeetingId}/participants/{participantId}` - 이벤트 탈퇴
+- **POST** `/events/{datingMeetingId}/participants` - 모임 참여
+  - Path Variable: `datingMeetingId` (Long - 내부 DB ID)
+  - Request Body: `JoinEventRequest` (userId - UUID)
+  - Response: `ParticipantResponse` (참여자 정보)
+  - 제약사항:
+    - 성별별 정원 확인 (남/여 각각)
+    - 중복 참여 불가
+    - DatingUser 활성 상태 확인
+
+- **DELETE** `/events/{datingMeetingId}/participants/{participantId}` - 모임 탈퇴
+  - Path Variables: `datingMeetingId` (Long), `participantId` (Long)
+  - Response: 204 No Content
 
 ## 📄 API 문서
 - Swagger UI: http://localhost:8080/swagger-ui.html
@@ -132,78 +165,55 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
 
 ---
 
-## 📝 TODO: 도메인 모델 개선 작업 목록
+## 📝 TODO: 향후 개선 작업 목록
 
-### 🚨 우선순위 높음 (Core Domain Issues)
+### ✅ 완료된 작업 (Completed)
+- [x] DatingUser 엔티티 추가 및 관계 설정 (Gender enum, Quarter 관리 포함)
+- [x] 성별 기반 정원 관리 시스템 (`maxMaleParticipants`, `maxFemaleParticipants`)
+- [x] Host User 개념 도입 (hostDatingUserId 필드)
+- [x] 성별 기반 정원 검증 로직 구현
+- [x] 참가자 중복 검증 및 비즈니스 룰 강화
+- [x] UUID 기반 Event-Driven Architecture 전환
+- [x] 이벤트 페이로드 UUID 기반 업데이트
+- [x] Outbox Pattern aggregateId를 String으로 변경
 
-#### 1. User 엔티티 추가 및 관계 설정
-- [ ] User 엔티티 생성 (id, username, gender, role, status 등)
-- [ ] Gender enum 추가 (MALE, FEMALE)
-- [ ] UserRole enum 추가 (USER, ADMIN 등)
-- [ ] Participant와 User 간 @ManyToOne 관계 설정
-- [ ] 기존 `Long userId` → `User user`로 변경
-- [ ] User Repository 및 Service 구현
+### 🔄 우선순위 높음 (High Priority)
 
-#### 2. 성별 기반 정원 관리 시스템
-- [ ] DatingMeeting에 `maxMaleParticipants`, `maxFemaleParticipants` 필드 추가
-- [ ] 기존 `maxParticipants` → 성별별 정원으로 분리
-- [ ] 성별별 정원 초과 검증 로직 구현
-- [ ] `getMaleParticipantsCount()`, `getFemaleParticipantsCount()` 메서드 추가
-- [ ] `isMaleFull()`, `isFemaleFull()` 검증 메서드 구현
+#### 1. Outbox Relay 구현
+- [ ] Outbox 테이블에서 PENDING 이벤트를 읽어 Kafka로 발행하는 별도 프로세스 구현
+- [ ] 발행 성공 시 Outbox 상태를 PROCESSED로 변경
+- [ ] 발행 실패 시 재시도 로직 및 FAILED 상태 처리
+- [ ] 배치 처리 및 트랜잭션 관리
 
-#### 3. Host User 개념 도입
-- [ ] DatingMeeting에 `hostUser` 필드 추가
-- [ ] 이벤트 생성 시 Host 지정 로직
-- [ ] Host 권한 검증 (수정/삭제는 Host만 가능)
-- [ ] CreateDatingMeetingRequest에 hostUserId 추가
-
-### 🔄 우선순위 중간 (Business Logic Enhancement)
-
-#### 4. 참가자 검증 로직 강화
-- [ ] 중복 참가 검증 강화 (현재 기본 구현됨)
-- [ ] 성별 기반 정원 검증 구현
-- [ ] 사용자별 동시 참가 제한 (최대 3개) 구현
-- [ ] User 활성 상태 검증 추가
-- [ ] `canAcceptParticipation()` 메서드 구현
-- [ ] `User.canRequest()` 검증 로직 구현
-
-#### 5. API 및 DTO 업데이트
-- [ ] CreateDatingMeetingRequest에 성별별 정원 필드 추가
-- [ ] UpdateDatingMeetingRequest에 성별별 정원 필드 추가
-- [ ] User 생성/조회 API 추가 (선택사항)
-- [ ] 에러 응답 메시지 개선 및 표준화
-- [ ] Swagger 문서 업데이트
-
-### 🧪 우선순위 낮음 (Testing & Advanced Features)
-
-#### 6. 테스트 케이스 추가
+#### 2. 테스트 케이스 추가
 - [ ] 성별별 정원 초과 시 예외 처리 테스트
-- [ ] User 미존재 시 예외 처리 테스트  
-- [ ] 중복 참가 방지 테스트 강화
-- [ ] Host 권한 테스트 (수정/삭제)
-- [ ] 사용자별 참가 제한 테스트
+- [ ] DatingUser 미존재 시 예외 처리 테스트
+- [ ] Host 권한 검증 테스트 (수정/삭제)
+- [ ] 참여자 탈퇴 처리 테스트
 - [ ] 통합 테스트 케이스 추가
 
-#### 7. 이벤트 페이로드 업데이트
-- [ ] User 정보 포함하도록 이벤트 구조 개선
-- [ ] 성별 정보 포함한 참가자 이벤트
-- [ ] Host 정보 포함한 미팅 생성 이벤트
-- [ ] 이벤트 스키마 버전 관리
+### 🧪 우선순위 중간 (Medium Priority)
 
-#### 8. 고급 기능 (선택사항)
+#### 3. 에러 처리 개선
+- [ ] 전역 예외 처리 (@ControllerAdvice)
+- [ ] 에러 응답 메시지 표준화
+- [ ] 비즈니스 예외 클래스 계층 구조 정립
+- [ ] HTTP Status 코드 일관성 검토
+
+#### 4. 고급 기능 (선택사항)
 - [ ] 참가 요청/승인 프로세스 도입
 - [ ] Vote 시스템 구현
 - [ ] 참가자 매칭 알고리즘
 - [ ] 지역 기반 필터링
 - [ ] 나이 제한 기능
 
-### 🔧 인프라 및 운영
+### 🔧 인프라 및 운영 (Low Priority)
 - [ ] 데이터베이스 마이그레이션 스크립트 작성
-- [ ] 기존 데이터 호환성 검토
 - [ ] 성능 테스트 (특히 성별별 집계 쿼리)
 - [ ] 모니터링 메트릭 추가
+- [ ] 로깅 전략 개선
 
 ---
 
-> **참고**: 이 작업들은 현재 과도하게 단순화된 도메인 모델을 실제 데이팅 서비스에 적합한 수준으로 개선하기 위한 것입니다. 
-> 우선순위에 따라 단계적으로 진행하되, Core Domain Issues부터 먼저 해결하는 것을 권장합니다.
+> **참고**: UUID 기반 EDA 전환 완료. DatingUser/Host 개념 및 성별별 정원 관리 시스템 구현 완료.
+> 현재 Outbox Relay 구현이 핵심 우선순위입니다.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
 | `DatingMeetingCreated` | DatingMeeting | 데이팅 이벤트 생성 | POST /events |
 | `DatingMeetingUpdated` | DatingMeeting | 데이팅 이벤트 수정 | PATCH /events/{id} |
 | `DatingMeetingDeleted` | DatingMeeting | 데이팅 이벤트 삭제 | DELETE /events/{id} |
-| `ParticipantJoined` | Participant | 이벤트 참여 | POST /events/{id}/participants |
-| `ParticipantLeft` | Participant | 이벤트 탈퇴 | DELETE /events/{id}/participants/{pid} |
+| `DatingMeetingParticipantJoined` | DatingMeetingParticipant | 이벤트 참여 | POST /events/{id}/participants |
+| `DatingMeetingParticipantLeft` | DatingMeetingParticipant | 이벤트 탈퇴 | DELETE /events/{id}/participants/{pid} |
 
 ### DatingMeetingCreated
 ```json
@@ -25,7 +25,7 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
   "aggregateType": "DatingMeeting",
   "aggregateId": 123,
   "data": {
-    "id": 123,
+    "datingMeetingId": 123,
     "title": "서울 강남 데이팅 모임",
     "description": "강남에서 만나는 데이팅 모임입니다",
     "meetingDateTime": "2024-08-21T19:00:00",
@@ -43,7 +43,7 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
   "aggregateType": "DatingMeeting",
   "aggregateId": 123,
   "data": {
-    "id": 123,
+    "datingMeetingId": 123,
     "title": "서울 강남 데이팅 모임 (수정)",
     "description": "강남에서 만나는 데이팅 모임입니다",
     "meetingDateTime": "2024-08-22T19:00:00",
@@ -61,7 +61,7 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
   "aggregateType": "DatingMeeting",
   "aggregateId": 123,
   "data": {
-    "id": 123,
+    "datingMeetingId": 123,
     "title": "서울 강남 데이팅 모임",
     "participantIds": [1, 2, 3],
     "deletedAt": "2024-08-21T16:00:00"
@@ -69,31 +69,31 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
 }
 ```
 
-### ParticipantJoined
+### DatingMeetingParticipantJoined
 ```json
 {
-  "eventType": "ParticipantJoined",
-  "aggregateType": "Participant",
+  "eventType": "DatingMeetingParticipantJoined",
+  "aggregateType": "DatingMeetingParticipant",
   "aggregateId": 456,
   "data": {
-    "eventId": 123,
+    "datingMeetingId": 123,
     "participantId": 456,
-    "userId": "user_987654321",
+    "userId": 987654321,
     "joinedAt": "2024-08-21T17:00:00"
   }
 }
 ```
 
-### ParticipantLeft
+### DatingMeetingParticipantLeft
 ```json
 {
-  "eventType": "ParticipantLeft",
-  "aggregateType": "Participant",
+  "eventType": "DatingMeetingParticipantLeft",
+  "aggregateType": "DatingMeetingParticipant",
   "aggregateId": 456,
   "data": {
-    "eventId": 123,
+    "datingMeetingId": 123,
     "participantId": 456,
-    "userId": "user_987654321",
+    "userId": 987654321,
     "leftAt": "2024-08-21T18:00:00"
   }
 }
@@ -108,12 +108,12 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
 
 ### 이벤트 관리
 - **POST** `/events` - 새 데이팅 이벤트 생성
-- **PATCH** `/events/{eventId}` - 이벤트 정보 부분 수정
-- **DELETE** `/events/{eventId}` - 이벤트 삭제
+- **PATCH** `/events/{datingMeetingId}` - 이벤트 정보 부분 수정
+- **DELETE** `/events/{datingMeetingId}` - 이벤트 삭제
 
 ### 참여자 관리
-- **POST** `/events/{eventId}/participants` - 이벤트 참여
-- **DELETE** `/events/{eventId}/participants/{participantId}` - 이벤트 탈퇴
+- **POST** `/events/{datingMeetingId}/participants` - 이벤트 참여
+- **DELETE** `/events/{datingMeetingId}/participants/{participantId}` - 이벤트 탈퇴
 
 ## 📄 API 문서
 - Swagger UI: http://localhost:8080/swagger-ui.html
@@ -129,3 +129,81 @@ CQRS Command Side로서 모든 상태 변경 시 Outbox 패턴을 통해 이벤�
 - 모든 서비스 메서드는 `@Transactional` 필수
 - 복잡한 조회 기능은 수행하지 않음 (Query Service 역할 아님)
 - 상태 변경과 Outbox 이벤트 기록의 원자성 보장
+
+---
+
+## 📝 TODO: 도메인 모델 개선 작업 목록
+
+### 🚨 우선순위 높음 (Core Domain Issues)
+
+#### 1. User 엔티티 추가 및 관계 설정
+- [ ] User 엔티티 생성 (id, username, gender, role, status 등)
+- [ ] Gender enum 추가 (MALE, FEMALE)
+- [ ] UserRole enum 추가 (USER, ADMIN 등)
+- [ ] Participant와 User 간 @ManyToOne 관계 설정
+- [ ] 기존 `Long userId` → `User user`로 변경
+- [ ] User Repository 및 Service 구현
+
+#### 2. 성별 기반 정원 관리 시스템
+- [ ] DatingMeeting에 `maxMaleParticipants`, `maxFemaleParticipants` 필드 추가
+- [ ] 기존 `maxParticipants` → 성별별 정원으로 분리
+- [ ] 성별별 정원 초과 검증 로직 구현
+- [ ] `getMaleParticipantsCount()`, `getFemaleParticipantsCount()` 메서드 추가
+- [ ] `isMaleFull()`, `isFemaleFull()` 검증 메서드 구현
+
+#### 3. Host User 개념 도입
+- [ ] DatingMeeting에 `hostUser` 필드 추가
+- [ ] 이벤트 생성 시 Host 지정 로직
+- [ ] Host 권한 검증 (수정/삭제는 Host만 가능)
+- [ ] CreateDatingMeetingRequest에 hostUserId 추가
+
+### 🔄 우선순위 중간 (Business Logic Enhancement)
+
+#### 4. 참가자 검증 로직 강화
+- [ ] 중복 참가 검증 강화 (현재 기본 구현됨)
+- [ ] 성별 기반 정원 검증 구현
+- [ ] 사용자별 동시 참가 제한 (최대 3개) 구현
+- [ ] User 활성 상태 검증 추가
+- [ ] `canAcceptParticipation()` 메서드 구현
+- [ ] `User.canRequest()` 검증 로직 구현
+
+#### 5. API 및 DTO 업데이트
+- [ ] CreateDatingMeetingRequest에 성별별 정원 필드 추가
+- [ ] UpdateDatingMeetingRequest에 성별별 정원 필드 추가
+- [ ] User 생성/조회 API 추가 (선택사항)
+- [ ] 에러 응답 메시지 개선 및 표준화
+- [ ] Swagger 문서 업데이트
+
+### 🧪 우선순위 낮음 (Testing & Advanced Features)
+
+#### 6. 테스트 케이스 추가
+- [ ] 성별별 정원 초과 시 예외 처리 테스트
+- [ ] User 미존재 시 예외 처리 테스트  
+- [ ] 중복 참가 방지 테스트 강화
+- [ ] Host 권한 테스트 (수정/삭제)
+- [ ] 사용자별 참가 제한 테스트
+- [ ] 통합 테스트 케이스 추가
+
+#### 7. 이벤트 페이로드 업데이트
+- [ ] User 정보 포함하도록 이벤트 구조 개선
+- [ ] 성별 정보 포함한 참가자 이벤트
+- [ ] Host 정보 포함한 미팅 생성 이벤트
+- [ ] 이벤트 스키마 버전 관리
+
+#### 8. 고급 기능 (선택사항)
+- [ ] 참가 요청/승인 프로세스 도입
+- [ ] Vote 시스템 구현
+- [ ] 참가자 매칭 알고리즘
+- [ ] 지역 기반 필터링
+- [ ] 나이 제한 기능
+
+### 🔧 인프라 및 운영
+- [ ] 데이터베이스 마이그레이션 스크립트 작성
+- [ ] 기존 데이터 호환성 검토
+- [ ] 성능 테스트 (특히 성별별 집계 쿼리)
+- [ ] 모니터링 메트릭 추가
+
+---
+
+> **참고**: 이 작업들은 현재 과도하게 단순화된 도메인 모델을 실제 데이팅 서비스에 적합한 수준으로 개선하기 위한 것입니다. 
+> 우선순위에 따라 단계적으로 진행하되, Core Domain Issues부터 먼저 해결하는 것을 권장합니다.

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/controller/DatingMeetingController.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/controller/DatingMeetingController.java
@@ -17,6 +17,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.UUID;
 
 @RestController
 @RequestMapping("/events")
@@ -34,8 +35,9 @@ public class DatingMeetingController {
             @ApiResponse(responseCode = "409", description = "미팅 생성 중 충돌 발생")
     })
     public ResponseEntity<DatingMeetingResponse> createDatingMeeting(
+            @Parameter(description = "인증된 사용자 ID (호스트)", required = true) @RequestHeader("X-User-Id") UUID userId,
             @Valid @RequestBody CreateDatingMeetingRequest request) {
-        DatingMeetingResponse response = datingMeetingService.createDatingMeeting(request);
+        DatingMeetingResponse response = datingMeetingService.createDatingMeeting(request, userId);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
@@ -77,7 +79,8 @@ public class DatingMeetingController {
     })
     public ResponseEntity<ParticipantResponse> joinEvent(
             @Parameter(description = "데이팅 미팅 ID") @PathVariable String datingMeetingId,
-            @Valid @RequestBody JoinEventRequest request) {
+            @Parameter(description = "인증된 사용자 ID", required = true) @RequestHeader("X-User-Id") UUID userId) {
+        JoinEventRequest request = new JoinEventRequest(userId);
         ParticipantResponse response = datingMeetingService.joinEvent(datingMeetingId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/controller/DatingMeetingController.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/controller/DatingMeetingController.java
@@ -39,7 +39,7 @@ public class DatingMeetingController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PatchMapping("/{eventId}")
+    @PatchMapping("/{datingMeetingId}")
     @Operation(summary = "이벤트 정보 부분 수정", description = "기존 데이팅 이벤트의 정보를 부분적으로 수정합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "이벤트 수정 성공"),
@@ -48,13 +48,13 @@ public class DatingMeetingController {
             @ApiResponse(responseCode = "409", description = "이벤트 수정 중 충돌 발생")
     })
     public ResponseEntity<DatingMeetingResponse> updateEvent(
-            @Parameter(description = "이벤트 ID") @PathVariable String eventId,
+            @Parameter(description = "데이팅 미팅 ID") @PathVariable String datingMeetingId,
             @Valid @RequestBody UpdateDatingMeetingRequest request) {
-        DatingMeetingResponse response = datingMeetingService.updateDatingMeeting(eventId, request);
+        DatingMeetingResponse response = datingMeetingService.updateDatingMeeting(datingMeetingId, request);
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/{eventId}")
+    @DeleteMapping("/{datingMeetingId}")
     @Operation(summary = "이벤트 삭제", description = "데이팅 이벤트를 삭제합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "이벤트 삭제 성공"),
@@ -62,12 +62,12 @@ public class DatingMeetingController {
             @ApiResponse(responseCode = "409", description = "참여자가 있어 삭제할 수 없음")
     })
     public ResponseEntity<Void> deleteEvent(
-            @Parameter(description = "이벤트 ID") @PathVariable String eventId) {
-        datingMeetingService.deleteDatingMeeting(eventId);
+            @Parameter(description = "데이팅 미팅 ID") @PathVariable String datingMeetingId) {
+        datingMeetingService.deleteDatingMeeting(datingMeetingId);
         return ResponseEntity.noContent().build();
     }
 
-    @PostMapping("/{eventId}/participants")
+    @PostMapping("/{datingMeetingId}/participants")
     @Operation(summary = "이벤트 참여", description = "데이팅 이벤트에 참여합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "201", description = "이벤트 참여 성공"),
@@ -76,13 +76,13 @@ public class DatingMeetingController {
             @ApiResponse(responseCode = "409", description = "이미 참여중이거나 정원 초과")
     })
     public ResponseEntity<ParticipantResponse> joinEvent(
-            @Parameter(description = "이벤트 ID") @PathVariable String eventId,
+            @Parameter(description = "데이팅 미팅 ID") @PathVariable String datingMeetingId,
             @Valid @RequestBody JoinEventRequest request) {
-        ParticipantResponse response = datingMeetingService.joinEvent(eventId, request);
+        ParticipantResponse response = datingMeetingService.joinEvent(datingMeetingId, request);
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @DeleteMapping("/{eventId}/participants/{participantId}")
+    @DeleteMapping("/{datingMeetingId}/participants/{participantId}")
     @Operation(summary = "이벤트 탈퇴", description = "데이팅 이벤트에서 탈퇴합니다.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "이벤트 탈퇴 성공"),
@@ -90,9 +90,9 @@ public class DatingMeetingController {
             @ApiResponse(responseCode = "409", description = "탈퇴할 수 없는 상태")
     })
     public ResponseEntity<Void> leaveEvent(
-            @Parameter(description = "이벤트 ID") @PathVariable String eventId,
+            @Parameter(description = "데이팅 미팅 ID") @PathVariable String datingMeetingId,
             @Parameter(description = "참여자 ID") @PathVariable Long participantId) {
-        datingMeetingService.leaveEvent(eventId, participantId);
+        datingMeetingService.leaveEvent(datingMeetingId, participantId);
         return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/DatingMeeting.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/DatingMeeting.java
@@ -4,6 +4,7 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
+import java.util.UUID;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -35,8 +36,12 @@ public class DatingMeeting extends BaseEntity {
     private String location;
 
     @Positive
-    @Column(nullable = false)
-    private Integer maxParticipants;
+    @Column(name = "max_male_participants", nullable = false)
+    private Integer maxMaleParticipants;
+
+    @Positive
+    @Column(name = "max_female_participants", nullable = false)
+    private Integer maxFemaleParticipants;
 
     @Version
     private Long version;
@@ -44,19 +49,23 @@ public class DatingMeeting extends BaseEntity {
     @OneToMany(mappedBy = "datingMeeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Participant> participants = new ArrayList<>();
 
-    private DatingMeeting(String title, String description, LocalDateTime meetingDateTime, String location, Integer maxParticipants) {
+    private DatingMeeting(String title, String description, LocalDateTime meetingDateTime, String location,
+                          Integer maxMaleParticipants, Integer maxFemaleParticipants) {
         this.title = title;
         this.description = description;
         this.meetingDateTime = meetingDateTime;
         this.location = location;
-        this.maxParticipants = maxParticipants;
+        this.maxMaleParticipants = maxMaleParticipants;
+        this.maxFemaleParticipants = maxFemaleParticipants;
     }
 
-    public static DatingMeeting create(String title, String description, LocalDateTime meetingDateTime, String location, Integer maxParticipants) {
-        return new DatingMeeting(title, description, meetingDateTime, location, maxParticipants);
+    public static DatingMeeting create(String title, String description, LocalDateTime meetingDateTime, String location,
+                                       Integer maxMaleParticipants, Integer maxFemaleParticipants) {
+        return new DatingMeeting(title, description, meetingDateTime, location, maxMaleParticipants, maxFemaleParticipants);
     }
 
-    public void update(String title, String description, LocalDateTime meetingDateTime, String location, Integer maxParticipants) {
+    public void update(String title, String description, LocalDateTime meetingDateTime, String location,
+                       Integer maxMaleParticipants, Integer maxFemaleParticipants) {
         if (title != null) {
             this.title = title;
         }
@@ -69,18 +78,48 @@ public class DatingMeeting extends BaseEntity {
         if (location != null) {
             this.location = location;
         }
-        if (maxParticipants != null) {
-            this.maxParticipants = maxParticipants;
+        if (maxMaleParticipants != null) {
+            this.maxMaleParticipants = maxMaleParticipants;
+        }
+        if (maxFemaleParticipants != null) {
+            this.maxFemaleParticipants = maxFemaleParticipants;
         }
     }
 
     public boolean isParticipantsFull() {
-        return this.participants.size() >= this.maxParticipants;
+        return isMaleFull() && isFemaleFull();
     }
 
-    public boolean hasParticipant(Long userId) {
+    public boolean isMaleFull() {
+        return getMaleParticipantsCount() >= this.maxMaleParticipants;
+    }
+
+    public boolean isFemaleFull() {
+        return getFemaleParticipantsCount() >= this.maxFemaleParticipants;
+    }
+
+    public int getMaleParticipantsCount() {
+        return (int) this.participants.stream()
+                .filter(Participant::isActive)
+                .filter(Participant::isMale)
+                .count();
+    }
+
+    public int getFemaleParticipantsCount() {
+        return (int) this.participants.stream()
+                .filter(Participant::isActive)
+                .filter(Participant::isFemale)
+                .count();
+    }
+
+    public boolean hasParticipant(UUID authUserId) {
         return this.participants.stream()
-                .anyMatch(participant -> participant.getUserId().equals(userId) && participant.isActive());
+                .anyMatch(participant -> participant.getAuthUserId().equals(authUserId) && participant.isActive());
+    }
+
+    public boolean hasParticipant(Long datingUserId) {
+        return this.participants.stream()
+                .anyMatch(participant -> participant.getDatingUserId().equals(datingUserId) && participant.isActive());
     }
 
     public int getCurrentParticipantCount() {

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/DatingMeeting.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/DatingMeeting.java
@@ -43,25 +43,40 @@ public class DatingMeeting extends BaseEntity {
     @Column(name = "max_female_participants", nullable = false)
     private Integer maxFemaleParticipants;
 
+    @NotNull
+    @Column(name = "host_dating_user_id", nullable = false)
+    private Long hostDatingUserId;
+
     @Version
     private Long version;
 
     @OneToMany(mappedBy = "datingMeeting", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Participant> participants = new ArrayList<>();
 
-    private DatingMeeting(String title, String description, LocalDateTime meetingDateTime, String location,
-                          Integer maxMaleParticipants, Integer maxFemaleParticipants) {
+    private DatingMeeting(String title,
+                          String description,
+                          Long hostDatingUserId,
+                          LocalDateTime meetingDateTime,
+                          String location,
+                          Integer maxMaleParticipants,
+                          Integer maxFemaleParticipants) {
         this.title = title;
         this.description = description;
+        this.hostDatingUserId = hostDatingUserId;
         this.meetingDateTime = meetingDateTime;
         this.location = location;
         this.maxMaleParticipants = maxMaleParticipants;
         this.maxFemaleParticipants = maxFemaleParticipants;
     }
 
-    public static DatingMeeting create(String title, String description, LocalDateTime meetingDateTime, String location,
-                                       Integer maxMaleParticipants, Integer maxFemaleParticipants) {
-        return new DatingMeeting(title, description, meetingDateTime, location, maxMaleParticipants, maxFemaleParticipants);
+    public static DatingMeeting create(String title,
+                                       String description,
+                                       Long hostDatingUserId,
+                                       LocalDateTime meetingDateTime,
+                                       String location,
+                                       Integer maxMaleParticipants,
+                                       Integer maxFemaleParticipants) {
+        return new DatingMeeting(title, description, hostDatingUserId, meetingDateTime, location, maxMaleParticipants, maxFemaleParticipants);
     }
 
     public void update(String title, String description, LocalDateTime meetingDateTime, String location,
@@ -96,6 +111,16 @@ public class DatingMeeting extends BaseEntity {
 
     public boolean isFemaleFull() {
         return getFemaleParticipantsCount() >= this.maxFemaleParticipants;
+    }
+
+    /**
+     * 특정 성별의 정원이 찼는지 확인
+     */
+    public boolean isGenderFull(DatingUser datingUser) {
+        if (datingUser.isMale()) {
+            return isMaleFull();
+        }
+        return isFemaleFull();
     }
 
     public int getMaleParticipantsCount() {

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/DatingMeeting.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/DatingMeeting.java
@@ -20,6 +20,10 @@ import java.util.List;
 public class DatingMeeting extends BaseEntity {
 
     @NotBlank
+    @Column(nullable = false, unique = true, updatable = false, length = 36)
+    private UUID meetingUuid = UUID.randomUUID();
+
+    @NotBlank
     @Column(nullable = false, length = 200)
     private String title;
 

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/DatingUser.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/DatingUser.java
@@ -1,0 +1,208 @@
+package com.grewmeet.dating.datingcommandservice.domain;
+
+import com.grewmeet.dating.datingcommandservice.domain.user.Gender;
+import com.grewmeet.dating.datingcommandservice.domain.user.UserRole;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * 분기별 데이팅 서비스 참여 자격 엔티티
+ * Auth Service의 User와는 별개로, 특정 분기 동안의 데이팅 서비스 이용 권한과 상태를 관리
+ */
+@Entity
+@Table(name = "dating_users", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"auth_user_id", "quarter"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class DatingUser extends BaseEntity {
+
+    private static final int DEFAULT_MAX_PARTICIPATIONS = 5;
+    private static final int MAX_CONCURRENT_PARTICIPATIONS = 3;
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "dating_user_id")
+    private Long id;
+
+    /**
+     * Auth Service의 User UUID 참조
+     */
+    @NotNull
+    @Column(name = "auth_user_id", nullable = false)
+    private UUID authUserId;
+
+    /**
+     * 분기 식별자 (예: "2025-Q1", "2025-Q2")
+     */
+    @NotBlank
+    @Column(nullable = false, length = 7)
+    private String quarter;
+
+    /**
+     * 닉네임 (호스트 신원 공개용)
+     */
+    @NotBlank
+    @Column(nullable = false, length = 50)
+    private String nickname;
+
+    /**
+     * 성별 (데이팅 매칭에 필요)
+     */
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 10)
+    private Gender gender;
+
+    /**
+     * 데이팅 서비스 내 권한 (BANNED, GUEST, PARTICIPANT, HOST, ADMIN)
+     */
+    @NotNull
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private UserRole role;
+
+    /**
+     * 현재 분기 참여 횟수
+     */
+    @Column(name = "quarter_participation_count", nullable = false)
+    private Integer quarterParticipationCount;
+
+    /**
+     * 분기당 최대 참여 가능 횟수
+     */
+    @Column(name = "max_participations", nullable = false)
+    private Integer maxParticipations;
+
+    /**
+     * 자격 유효 종료일 (분기 마지막 날)
+     */
+    @Column(name = "valid_until")
+    private LocalDateTime validUntil;
+
+    /**
+     * 참여 이력
+     */
+    @OneToMany(mappedBy = "datingUser", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
+    private List<Participant> participants = new ArrayList<>();
+
+    private DatingUser(UUID authUserId, String quarter, String nickname, Gender gender, UserRole role, LocalDateTime validUntil) {
+        this.authUserId = authUserId;
+        this.quarter = quarter;
+        this.nickname = nickname;
+        this.gender = gender;
+        this.role = role;
+        this.quarterParticipationCount = 0;
+        this.maxParticipations = DEFAULT_MAX_PARTICIPATIONS;
+        this.validUntil = validUntil;
+    }
+
+    public static DatingUser create(UUID authUserId, String quarter, String nickname, Gender gender, UserRole role, LocalDateTime validUntil) {
+        return new DatingUser(authUserId, quarter, nickname, gender, role, validUntil);
+    }
+
+    // === 비즈니스 로직 메서드 ===
+
+    public boolean isMale() {
+        return this.gender == Gender.MALE;
+    }
+
+    public boolean isFemale() {
+        return this.gender == Gender.FEMALE;
+    }
+
+    public boolean isBanned() {
+        return this.role == UserRole.BANNED;
+    }
+
+    public boolean isHost() {
+        return this.role == UserRole.HOST || this.role == UserRole.ADMIN;
+    }
+
+    /**
+     * 이벤트 생성 가능 여부
+     */
+    public boolean canCreateEvent() {
+        return !isBanned() && isHost();
+    }
+
+    /**
+     * 이벤트 참여 가능 여부 (권한 기반)
+     */
+    public boolean canParticipateInEvents() {
+        return !isBanned();
+    }
+
+    /**
+     * 현재 활성 참여 수
+     */
+    public int getActiveParticipationCount() {
+        return (int) participants.stream()
+                .filter(Participant::isActive)
+                .count();
+    }
+
+    /**
+     * 동시 참여 제한 체크
+     */
+    public boolean canParticipateMoreEvents() {
+        return getActiveParticipationCount() < MAX_CONCURRENT_PARTICIPATIONS;
+    }
+
+    /**
+     * 분기 참여 횟수 제한 체크
+     */
+    public boolean canParticipateInQuarter() {
+        return quarterParticipationCount < maxParticipations;
+    }
+
+    /**
+     * 전체 참여 가능 여부
+     */
+    public boolean canParticipate() {
+        return canParticipateInEvents()
+            && canParticipateMoreEvents()
+            && canParticipateInQuarter();
+    }
+
+    /**
+     * 특정 이벤트에 이미 참여 중인지 확인
+     */
+    public boolean hasActiveParticipationInEvent(Long datingMeetingId) {
+        return participants.stream()
+                .filter(Participant::isActive)
+                .anyMatch(p -> p.getDatingMeeting().getId().equals(datingMeetingId));
+    }
+
+    /**
+     * 참여 횟수 증가
+     */
+    public void incrementParticipation() {
+        this.quarterParticipationCount++;
+    }
+
+    /**
+     * 참여 횟수 감소 (탈퇴 시)
+     */
+    public void decrementParticipation() {
+        if (this.quarterParticipationCount > 0) {
+            this.quarterParticipationCount--;
+        }
+    }
+
+    /**
+     * 자격 유효성 검증
+     */
+    public boolean isValid() {
+        return validUntil == null || LocalDateTime.now().isBefore(validUntil);
+    }
+}

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/Outbox.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/Outbox.java
@@ -27,8 +27,9 @@ public class Outbox extends BaseEntity {
     @Column(nullable = false, length = 100)
     private String aggregateType;
 
-    @Column(nullable = false)
-    private Long aggregateId;
+    @NotBlank
+    @Column(nullable = false, length = 36)
+    private String aggregateId;
 
     @NotBlank
     @Column(nullable = false, columnDefinition = "TEXT")
@@ -42,7 +43,7 @@ public class Outbox extends BaseEntity {
 
     private String errorMessage;
 
-    private Outbox(String eventType, String aggregateType, Long aggregateId, String payload) {
+    private Outbox(String eventType, String aggregateType, String aggregateId, String payload) {
         this.eventType = eventType;
         this.aggregateType = aggregateType;
         this.aggregateId = aggregateId;
@@ -50,7 +51,7 @@ public class Outbox extends BaseEntity {
         this.status = OutboxStatus.PENDING;
     }
 
-    public static Outbox create(String eventType, String aggregateType, Long aggregateId, String payload) {
+    public static Outbox create(String eventType, String aggregateType, String aggregateId, String payload) {
         return new Outbox(eventType, aggregateType, aggregateId, payload);
     }
 

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/Outbox.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/Outbox.java
@@ -17,7 +17,7 @@ public class Outbox extends BaseEntity {
 
     @NotBlank
     @Column(nullable = false, unique = true)
-    private String eventId = UUID.randomUUID().toString();
+    private String outboxEventId = UUID.randomUUID().toString();
 
     @NotBlank
     @Column(nullable = false, length = 100)

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/Participant.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/Participant.java
@@ -6,6 +6,8 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.UUID;
+
 
 @Entity
 @Table(name = "participants")
@@ -14,8 +16,9 @@ import lombok.NoArgsConstructor;
 public class Participant extends BaseEntity {
 
     @NotNull
-    @Column(nullable = false)
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dating_user_id", nullable = false)
+    private DatingUser datingUser;
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
@@ -23,17 +26,17 @@ public class Participant extends BaseEntity {
     private DatingMeeting datingMeeting;
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(nullable = false, length = 20)
     private ParticipantStatus status = ParticipantStatus.ACTIVE;
 
-    private Participant(Long userId, DatingMeeting datingMeeting) {
-        this.userId = userId;
+    private Participant(DatingUser datingUser, DatingMeeting datingMeeting) {
+        this.datingUser = datingUser;
         this.datingMeeting = datingMeeting;
         this.status = ParticipantStatus.ACTIVE;
     }
 
-    public static Participant create(Long userId, DatingMeeting datingMeeting) {
-        return new Participant(userId, datingMeeting);
+    public static Participant create(DatingUser datingUser, DatingMeeting datingMeeting) {
+        return new Participant(datingUser, datingMeeting);
     }
 
     public void withdraw() {
@@ -42,6 +45,22 @@ public class Participant extends BaseEntity {
 
     public boolean isActive() {
         return this.status == ParticipantStatus.ACTIVE;
+    }
+
+    public boolean isMale() {
+        return datingUser.isMale();
+    }
+
+    public boolean isFemale() {
+        return datingUser.isFemale();
+    }
+
+    public UUID getAuthUserId() {
+        return datingUser.getAuthUserId();
+    }
+
+    public Long getDatingUserId() {
+        return datingUser.getId();
     }
 
     public enum ParticipantStatus {

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/user/Entitlement.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/user/Entitlement.java
@@ -1,0 +1,8 @@
+package com.grewmeet.dating.datingcommandservice.domain.user;
+
+public enum Entitlement {
+    CAN_PARTICIPATE,    // 이벤트 참여 권한
+    CAN_CREATE,         // 이벤트 생성 권한
+    CAN_CANCEL,         // 이벤트 취소 권한
+    CAN_MANAGE_USERS    // 사용자 관리 권한 (Admin용)
+}

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/user/Gender.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/user/Gender.java
@@ -1,0 +1,6 @@
+package com.grewmeet.dating.datingcommandservice.domain.user;
+
+public enum Gender {
+    MALE,
+    FEMALE
+}

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/domain/user/UserRole.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/domain/user/UserRole.java
@@ -1,0 +1,27 @@
+package com.grewmeet.dating.datingcommandservice.domain.user;
+
+import java.util.Set;
+
+import static com.grewmeet.dating.datingcommandservice.domain.user.Entitlement.*;
+
+public enum UserRole {
+    
+    GUEST(Set.of(CAN_PARTICIPATE)),
+    HOST(Set.of(CAN_PARTICIPATE, CAN_CREATE, CAN_CANCEL)),
+    ADMIN(Set.of(CAN_PARTICIPATE, CAN_CREATE, CAN_CANCEL, CAN_MANAGE_USERS)),
+    BANNED(null);
+
+    private final Set<Entitlement> capabilities;
+
+    UserRole(Set<Entitlement> capabilities) {
+        this.capabilities = capabilities;
+    }
+
+    public boolean can(Entitlement entitlement) {
+        return capabilities.contains(entitlement);
+    }
+
+    public Set<Entitlement> getCapabilities() {
+        return Set.copyOf(capabilities);
+    }
+}

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/dto/request/CreateDatingMeetingRequest.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/dto/request/CreateDatingMeetingRequest.java
@@ -21,8 +21,13 @@ public record CreateDatingMeetingRequest(
         @Size(max = 300, message = "장소는 300자를 초과할 수 없습니다")
         String location,
 
-        @NotNull(message = "최대 참여자 수는 필수입니다")
-        @Min(value = 2, message = "최대 참여자 수는 최소 2명 이상이어야 합니다")
-        @Max(value = 100, message = "최대 참여자 수는 100명을 초과할 수 없습니다")
-        Integer maxParticipants
+        @NotNull(message = "최대 남성 참여자 수는 필수입니다")
+        @Min(value = 1, message = "최대 남성 참여자 수는 최소 1명 이상이어야 합니다")
+        @Max(value = 50, message = "최대 남성 참여자 수는 50명을 초과할 수 없습니다")
+        Integer maxMaleParticipants,
+
+        @NotNull(message = "최대 여성 참여자 수는 필수입니다")
+        @Min(value = 1, message = "최대 여성 참여자 수는 최소 1명 이상이어야 합니다")
+        @Max(value = 50, message = "최대 여성 참여자 수는 50명을 초과할 수 없습니다")
+        Integer maxFemaleParticipants
 ) {}

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/dto/request/JoinEventRequest.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/dto/request/JoinEventRequest.java
@@ -1,9 +1,10 @@
 package com.grewmeet.dating.datingcommandservice.dto.request;
 
 import jakarta.validation.constraints.NotNull;
+import java.util.UUID;
 
 public record JoinEventRequest(
     @NotNull(message = "사용자 ID는 필수입니다.")
-    Long userId
+    UUID userId
 ) {
 }

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/dto/request/UpdateDatingMeetingRequest.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/dto/request/UpdateDatingMeetingRequest.java
@@ -17,7 +17,11 @@ public record UpdateDatingMeetingRequest(
         @Size(max = 300, message = "장소는 300자를 초과할 수 없습니다")
         String location,
 
-        @Min(value = 2, message = "최대 참여자 수는 최소 2명 이상이어야 합니다")
-        @Max(value = 100, message = "최대 참여자 수는 100명을 초과할 수 없습니다")
-        Integer maxParticipants
+        @Min(value = 1, message = "최대 남성 참여자 수는 최소 1명 이상이어야 합니다")
+        @Max(value = 50, message = "최대 남성 참여자 수는 50명을 초과할 수 없습니다")
+        Integer maxMaleParticipants,
+
+        @Min(value = 1, message = "최대 여성 참여자 수는 최소 1명 이상이어야 합니다")
+        @Max(value = 50, message = "최대 여성 참여자 수는 50명을 초과할 수 없습니다")
+        Integer maxFemaleParticipants
 ) {}

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/event/OutboxService.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/event/OutboxService.java
@@ -17,16 +17,16 @@ public class OutboxService {
     private final ObjectMapper objectMapper;
 
     @Transactional
-    public void publishEvent(String eventType, String aggregateType, Long aggregateId, Object eventData) {
+    public void publishEvent(String eventType, String aggregateType, String aggregateId, Object eventData) {
         try {
             String payload = objectMapper.writeValueAsString(eventData);
             Outbox outboxEvent = Outbox.create(eventType, aggregateType, aggregateId, payload);
             outboxRepository.save(outboxEvent);
-            
-            log.info("Outbox event saved: eventType={}, aggregateType={}, aggregateId={}", 
+
+            log.info("Outbox event saved: eventType={}, aggregateType={}, aggregateId={}",
                     eventType, aggregateType, aggregateId);
         } catch (Exception e) {
-            log.error("Failed to publish outbox event: eventType={}, aggregateType={}, aggregateId={}", 
+            log.error("Failed to publish outbox event: eventType={}, aggregateType={}, aggregateId={}",
                     eventType, aggregateType, aggregateId, e);
             throw new RuntimeException("Failed to publish outbox event", e);
         }

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/repository/DatingMeetingRepository.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/repository/DatingMeetingRepository.java
@@ -1,9 +1,12 @@
 package com.grewmeet.dating.datingcommandservice.repository;
 
 import com.grewmeet.dating.datingcommandservice.domain.DatingMeeting;
+import java.lang.ScopedValue;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface DatingMeetingRepository extends JpaRepository<DatingMeeting, Long> {
+    <T> ScopedValue<T> findById(UUID id);
 }

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/repository/DatingUserRepository.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/repository/DatingUserRepository.java
@@ -1,0 +1,27 @@
+package com.grewmeet.dating.datingcommandservice.repository;
+
+import com.grewmeet.dating.datingcommandservice.domain.DatingUser;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+import java.util.UUID;
+
+@Repository
+public interface DatingUserRepository extends JpaRepository<DatingUser, Long> {
+
+    /**
+     * Auth User ID와 분기로 DatingUser 조회
+     */
+    Optional<DatingUser> findByAuthUserIdAndQuarter(UUID authUserId, String quarter);
+
+    /**
+     * Auth User ID와 분기로 존재 여부 확인
+     */
+    boolean existsByAuthUserIdAndQuarter(UUID authUserId, String quarter);
+
+    /**
+     * Auth User ID로 모든 DatingUser 조회 (분기별)
+     */
+    java.util.List<DatingUser> findByAuthUserId(UUID authUserId);
+}

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingCreated.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingCreated.java
@@ -2,24 +2,31 @@ package com.grewmeet.dating.datingcommandservice.saga;
 
 import com.grewmeet.dating.datingcommandservice.domain.DatingMeeting;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record DatingMeetingCreated(
-        Long datingMeetingId,
+        UUID meetingUuid,
         String title,
         String description,
+        UUID hostAuthUserId,
+        String hostNickname,
         LocalDateTime meetingDateTime,
         String location,
-        Integer maxParticipants,
+        Integer maxMaleParticipants,
+        Integer maxFemaleParticipants,
         LocalDateTime createdAt
 ) {
-    public static DatingMeetingCreated from(DatingMeeting datingMeeting) {
+    public static DatingMeetingCreated from(DatingMeeting datingMeeting, UUID hostAuthUserId, String hostNickname) {
         return new DatingMeetingCreated(
-                datingMeeting.getId(),
+                datingMeeting.getMeetingUuid(),
                 datingMeeting.getTitle(),
                 datingMeeting.getDescription(),
+                hostAuthUserId,
+                hostNickname,
                 datingMeeting.getMeetingDateTime(),
                 datingMeeting.getLocation(),
-                datingMeeting.getMaxParticipants(),
+                datingMeeting.getMaxMaleParticipants(),
+                datingMeeting.getMaxFemaleParticipants(),
                 datingMeeting.getCreatedAt()
         );
     }

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingDeleted.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingDeleted.java
@@ -3,32 +3,32 @@ package com.grewmeet.dating.datingcommandservice.saga;
 import com.grewmeet.dating.datingcommandservice.domain.DatingMeeting;
 import com.grewmeet.dating.datingcommandservice.domain.Participant;
 import java.time.LocalDateTime;
-import java.util.List;
+import java.util.UUID;
 
 public record DatingMeetingDeleted(
-        Long datingMeetingId,
-        String title,
-        String description,
-        LocalDateTime meetingDateTime,
-        String location,
-        Integer maxParticipants,
-        List<Long> participantIds,
+        UUID datingMeetingId,
         LocalDateTime deletedAt
 ) {
+//    public static DatingMeetingDeleted from(DatingMeeting datingMeeting) {
+//        List<UUID> participantIds = datingMeeting.getParticipants().stream()
+//                .filter(Participant::isActive)
+//                .map(Participant::getAuthUserId)
+//                .toList();
+//
+//        return new DatingMeetingDeleted(
+//                datingMeeting.getId(),
+//                datingMeeting.getTitle(),
+//                datingMeeting.getDescription(),
+//                datingMeeting.getMeetingDateTime(),
+//                datingMeeting.getLocation(),
+//                datingMeeting.getMaxParticipants(),
+//                participantIds,
+//                LocalDateTime.now()
+//        );
+//    }
     public static DatingMeetingDeleted from(DatingMeeting datingMeeting) {
-        List<Long> participantIds = datingMeeting.getParticipants().stream()
-                .filter(Participant::isActive)
-                .map(Participant::getUserId)
-                .toList();
-        
         return new DatingMeetingDeleted(
-                datingMeeting.getId(),
-                datingMeeting.getTitle(),
-                datingMeeting.getDescription(),
-                datingMeeting.getMeetingDateTime(),
-                datingMeeting.getLocation(),
-                datingMeeting.getMaxParticipants(),
-                participantIds,
+                datingMeeting.getMeetingUuid(),
                 LocalDateTime.now()
         );
     }

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingParticipantJoinedEvent.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingParticipantJoinedEvent.java
@@ -2,7 +2,7 @@ package com.grewmeet.dating.datingcommandservice.saga;
 
 import java.time.LocalDateTime;
 
-public record ParticipantJoinedEvent(
+public record DatingMeetingParticipantJoinedEvent(
         Long datingMeetingId,
         Long participantId,
         Long userId,

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingParticipantJoinedEvent.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingParticipantJoinedEvent.java
@@ -1,10 +1,13 @@
 package com.grewmeet.dating.datingcommandservice.saga;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record DatingMeetingParticipantJoinedEvent(
-        Long datingMeetingId,
-        Long participantId,
-        Long userId,
+        UUID meetingUuid,
+        UUID authUserId,
+        String gender,             // Query: 정원 계산
+        String meetingTitle,       // Schedule: 일정 제목
+        LocalDateTime meetingDateTime, // Schedule: 일정 일시
         LocalDateTime joinedAt
 ) {}

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingParticipantLeftEvent.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingParticipantLeftEvent.java
@@ -1,10 +1,11 @@
 package com.grewmeet.dating.datingcommandservice.saga;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record DatingMeetingParticipantLeftEvent(
-        Long datingMeetingId,
-        Long participantId,
-        Long userId,
+        UUID meetingUuid,
+        UUID authUserId,
+        String gender,             // Query: 정원 재계산
         LocalDateTime leftAt
 ) {}

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingParticipantLeftEvent.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingParticipantLeftEvent.java
@@ -2,7 +2,7 @@ package com.grewmeet.dating.datingcommandservice.saga;
 
 import java.time.LocalDateTime;
 
-public record ParticipantLeftEvent(
+public record DatingMeetingParticipantLeftEvent(
         Long datingMeetingId,
         Long participantId,
         Long userId,

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingUpdated.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/saga/DatingMeetingUpdated.java
@@ -2,24 +2,27 @@ package com.grewmeet.dating.datingcommandservice.saga;
 
 import com.grewmeet.dating.datingcommandservice.domain.DatingMeeting;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 public record DatingMeetingUpdated(
-        Long datingMeetingId,
+        UUID meetingUuid,
         String title,
         String description,
         LocalDateTime meetingDateTime,
         String location,
-        Integer maxParticipants,
+        Integer maxMaleParticipants,
+        Integer maxFemaleParticipants,
         LocalDateTime updatedAt
 ) {
     public static DatingMeetingUpdated from(DatingMeeting datingMeeting) {
         return new DatingMeetingUpdated(
-                datingMeeting.getId(),
+                datingMeeting.getMeetingUuid(),
                 datingMeeting.getTitle(),
                 datingMeeting.getDescription(),
                 datingMeeting.getMeetingDateTime(),
                 datingMeeting.getLocation(),
-                datingMeeting.getMaxParticipants(),
+                datingMeeting.getMaxMaleParticipants(),
+                datingMeeting.getMaxFemaleParticipants(),
                 datingMeeting.getUpdatedAt()
         );
     }

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/service/DatingMeetingService.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/service/DatingMeetingService.java
@@ -5,9 +5,10 @@ import com.grewmeet.dating.datingcommandservice.dto.request.JoinEventRequest;
 import com.grewmeet.dating.datingcommandservice.dto.request.UpdateDatingMeetingRequest;
 import com.grewmeet.dating.datingcommandservice.dto.response.DatingMeetingResponse;
 import com.grewmeet.dating.datingcommandservice.dto.response.ParticipantResponse;
+import java.util.UUID;
 
 public interface DatingMeetingService {
-    DatingMeetingResponse createDatingMeeting(CreateDatingMeetingRequest request);
+    DatingMeetingResponse createDatingMeeting(CreateDatingMeetingRequest request, UUID hostId);
     DatingMeetingResponse updateDatingMeeting(String datingMeetingId, UpdateDatingMeetingRequest request);
     void deleteDatingMeeting(String datingMeetingId);
     ParticipantResponse joinEvent(String datingMeetingId, JoinEventRequest request);

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/service/DatingMeetingService.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/service/DatingMeetingService.java
@@ -8,8 +8,8 @@ import com.grewmeet.dating.datingcommandservice.dto.response.ParticipantResponse
 
 public interface DatingMeetingService {
     DatingMeetingResponse createDatingMeeting(CreateDatingMeetingRequest request);
-    DatingMeetingResponse updateDatingMeeting(String eventId, UpdateDatingMeetingRequest request);
-    void deleteDatingMeeting(String eventId);
-    ParticipantResponse joinEvent(String eventId, JoinEventRequest request);
-    void leaveEvent(String eventId, Long participantId);
+    DatingMeetingResponse updateDatingMeeting(String datingMeetingId, UpdateDatingMeetingRequest request);
+    void deleteDatingMeeting(String datingMeetingId);
+    ParticipantResponse joinEvent(String datingMeetingId, JoinEventRequest request);
+    void leaveEvent(String datingMeetingId, Long participantId);
 }

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/service/DatingMeetingServiceImpl.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/service/DatingMeetingServiceImpl.java
@@ -38,7 +38,8 @@ public class DatingMeetingServiceImpl implements DatingMeetingService {
                 request.description(),
                 request.meetingDateTime(),
                 request.location(),
-                request.maxParticipants()
+                request.maxMaleParticipants(),
+                request.maxFemaleParticipants()
         );
 
         DatingMeeting savedDatingMeeting = datingMeetingRepository.save(datingMeeting);
@@ -62,7 +63,8 @@ public class DatingMeetingServiceImpl implements DatingMeetingService {
                 request.description(),
                 request.meetingDateTime(),
                 request.location(),
-                request.maxParticipants()
+                request.maxMaleParticipants(),
+                request.maxFemaleParticipants()
         );
 
         DatingMeeting updatedDatingMeeting = datingMeetingRepository.save(datingMeeting);

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/util/IdParser.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/util/IdParser.java
@@ -1,5 +1,7 @@
 package com.grewmeet.dating.datingcommandservice.util;
 
+import java.util.UUID;
+
 public class IdParser {
 
     public static Long parseDatingMeetingId(String datingMeetingId) {
@@ -8,7 +10,7 @@ public class IdParser {
         }
         
         try {
-            return Long.parseLong(datingMeetingId.trim());
+            return Long.parseLong(datingMeetingId);
         } catch (NumberFormatException e) {
             throw new IllegalArgumentException("Invalid dating meeting ID format: " + datingMeetingId, e);
         }

--- a/src/main/java/com/grewmeet/dating/datingcommandservice/util/IdParser.java
+++ b/src/main/java/com/grewmeet/dating/datingcommandservice/util/IdParser.java
@@ -2,15 +2,15 @@ package com.grewmeet.dating.datingcommandservice.util;
 
 public class IdParser {
 
-    public static Long parseEventId(String eventId) {
-        if (eventId == null || eventId.trim().isEmpty()) {
-            throw new IllegalArgumentException("Event ID cannot be null or empty");
+    public static Long parseDatingMeetingId(String datingMeetingId) {
+        if (datingMeetingId == null || datingMeetingId.trim().isEmpty()) {
+            throw new IllegalArgumentException("Dating meeting ID cannot be null or empty");
         }
         
         try {
-            return Long.parseLong(eventId.trim());
+            return Long.parseLong(datingMeetingId.trim());
         } catch (NumberFormatException e) {
-            throw new IllegalArgumentException("Invalid event ID format: " + eventId, e);
+            throw new IllegalArgumentException("Invalid dating meeting ID format: " + datingMeetingId, e);
         }
     }
 }

--- a/src/test/java/com/grewmeet/dating/datingcommandservice/service/EventParticipationServiceTest.java
+++ b/src/test/java/com/grewmeet/dating/datingcommandservice/service/EventParticipationServiceTest.java
@@ -69,7 +69,7 @@ class EventParticipationServiceTest {
         assertThat(response.status()).isEqualTo(Participant.ParticipantStatus.ACTIVE);
         
         verify(participantRepository).save(any(Participant.class));
-        verify(outboxService).publishEvent(eq("ParticipantJoined"), eq("Participant"), any(), any());
+        verify(outboxService).publishEvent(eq("DatingMeetingParticipantJoined"), eq("DatingMeetingParticipant"), any(), any());
     }
 
     @Test
@@ -146,7 +146,7 @@ class EventParticipationServiceTest {
         assertThat(participant.getStatus()).isEqualTo(Participant.ParticipantStatus.WITHDRAWN);
         
         verify(participantRepository).save(participant);
-        verify(outboxService).publishEvent(eq("ParticipantLeft"), eq("Participant"), any(), any());
+        verify(outboxService).publishEvent(eq("DatingMeetingParticipantLeft"), eq("DatingMeetingParticipant"), any(), any());
     }
 
     @Test


### PR DESCRIPTION
- DatingMeeting에 meetingUuid 필드 추가 (외부 이벤트 식별용)
- Outbox aggregateId 타입을 Long → String으로 변경
- 모든 이벤트 스키마를 UUID 기반으로 전환
  - DatingMeetingCreated: host 정보 및 성별별 정원 추가
  - DatingMeetingDeleted: participantIds 제거 (불필요)
  - ParticipantJoined: 익명성 유지, Schedule Service 지원
   - ParticipantLeft: gender 정보 추가
- OutboxService 시그니처 업데이트 (aggregateId: Long → String)
- README.md 전면 개선
  - 이벤트 스키마 예제를 UUID 기반으로 업데이트
  - 완료된 TODO 항목 정리
  - API 엔드포인트 상세 설명 추가